### PR TITLE
Ошибка в коде yblock.md

### DIFF
--- a/practice/yblock.md
+++ b/practice/yblock.md
@@ -643,7 +643,7 @@ modules.define(
             _onClearClicked: function () {
                 if (this.isEnabled()) {
                     this.setValue('');
-                    this.focus();
+                    this._control.focus();
                 }
             },
 


### PR DESCRIPTION
Фокус должен быть на поле, и уже после этого будет вызван метод `focus()`.